### PR TITLE
aarch64 (linux/arm64) container host support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG ZEPHYR_ZREPO_VERSION="3.3.0"
 ARG WGET_ARGS="-q --progress=dot:giga --no-check-certificate"
 
 # Container host platform, set automatically by `docker build`
-ARG TARGETPLATFORM
+ARG TARGETPLATFORM="linux/amd64"
 
 # Setup environment
 ENV DEBIAN_FRONTEND="noninteractive"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM buildpack-deps:jammy-scm
 ARG CMAKE_VERSION="3.20.5"
 ARG ZSDK_VERSION="0.15.2"
 ARG ZEPHYR_ZREPO_VERSION="3.3.0"
-#ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
-ARG WGET_ARGS="--show-progress --progress=bar:force:noscroll --no-check-certificate"
+ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
 
 ARG PKGS
 ARG PKGS_amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ ENV LANG="C.UTF-8"
 
 # Install needed packages
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		ccache \
 		clang-format \
 		device-tree-compiler \
@@ -34,8 +35,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		file \
 		g++ \
 		gcc \
-		gcc-multilib \
-		g++-multilib \
 		git \
 		gperf \
 		lbzip2 \
@@ -55,7 +54,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		wget \
 		xz-utils \
 		zip \
-	  && rm -rf /var/lib/apt/lists/*
+	&& arch="$(dpkg --print-architecture)" \
+	&& if [ "${arch}" == "amd64" ]; then \
+		apt-get install -y --no-install-recommends \
+			gcc-multilib \
+			g++-multilib; \
+		fi \
+	&& rm -rf /var/lib/apt/lists/*
+
 
 #
 # Install CMake

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update \
 		xz-utils \
 		zip \
 	&& arch="$(dpkg --print-architecture)" \
-	&& if [ "${arch}" == "amd64" ]; then \
+	&& if [ "${arch}" = "amd64" ]; then \
 		apt-get install -y --no-install-recommends \
 			gcc-multilib \
 			g++-multilib; \
@@ -67,7 +67,7 @@ RUN apt-get update \
 # Install CMake
 #
 
-# hadolint ignore=DL3047,DL3066
+# hadolint ignore=DL3047
 RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
 	&& CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-Linux-${arch}.sh" \
 	&& CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_INSTALLER}" \
@@ -83,7 +83,7 @@ WORKDIR "/opt/toolchains"
 # Install Zephyr SDK
 #
 
-# hadolint ignore=DL3047,DL3066
+# hadolint ignore=DL3047
 RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
 	&& ZEPHYR_SDK_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}_linux-${arch}.tar.gz" \
 	&& wget ${WGET_ARGS} "${ZEPHYR_SDK_URL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
+#
+# Copyright (c) 2019-2023 Blue Clover Devices
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 # bcdevices/zsdk-zephyr-jammy
 FROM buildpack-deps:jammy-scm
 
 ARG CMAKE_VERSION="3.20.5"
 ARG ZSDK_VERSION="0.15.2"
-ARG ZEPHYR_ZREPO_VERSION="3.3.0"
-ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
+ARG ZEPHYR_VERSION="3.3.0"
+
+ARG CMAKE_ROOT_DIR="/usr/local"
+ARG ZSDK_ROOT_DIR="/opt/toolchains"
+ARG ZEPHYR_ROOT_DIR="/usr/src"
+ARG ZEPHYR_INSTALL_DIR="${ZEPHYR_SRC_DIR}/zephyr-${ZEPHYR_VERSION}"
 
 ARG PKGS
-ARG PKGS_amd64
 ENV PKGS="${PKGS} ccache"
 ENV PKGS="${PKGS} clang-format"
 ENV PKGS="${PKGS} device-tree-compiler"
 ENV PKGS="${PKGS} dfu-util"
 ENV PKGS="${PKGS} file"
 ENV PKGS="${PKGS} g++"
-ENV PKGS_amd64="${PKGS_amd64} g++-multilib"
 ENV PKGS="${PKGS} gcc"
-ENV PKGS_amd64="${PKGS_amd64} gcc-multilib"
 ENV PKGS="${PKGS} git"
 ENV PKGS="${PKGS} gperf"
 ENV PKGS="${PKGS} lbzip2"
@@ -37,74 +44,69 @@ ENV PKGS="${PKGS} wget"
 ENV PKGS="${PKGS} xz-utils"
 ENV PKGS="${PKGS} zip"
 
-## Setup environment
+ARG PKGS_amd64
+ENV PKGS_amd64="${PKGS_amd64} g++-multilib"
+ENV PKGS_amd64="${PKGS_amd64} gcc-multilib"
+
+ARG WGET_ARGS="--progress=bar:force:noscroll --no-check-certificate"
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV TERM="xterm"
 
-## Setup locale
-
+# DL3008: `apt-get install <package>=<version>`
 # hadolint ignore=DL3008
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		locales \
+	&& apt-get install -y --no-install-recommends locales \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' "/etc/locale.gen" \
+	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
 	&& dpkg-reconfigure --frontend=noninteractive locales \
-	&& update-locale
+	&& update-locale \
+	&& mkdir -p "${CMAKE_ROOT_DIR}" "${ZEPHYR_ROOT_DIR}" "${ZSDK_ROOT_DIR}"
 
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"
 ENV LANG="C.UTF-8"
 
-## Install needed packages
-
+# DL3008: `apt-get install <package>=<version>`
 # hadolint ignore=DL3008
-RUN arch="$(dpkg --print-architecture)" \
-	&& if [ "${arch}" = "amd64" ]; then PKGS="${PKGS} ${PKGS_amd64}"; fi \
-	&& apt-get update \
+RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ${PKGS} \
+	&& if [ "$(dpkg --print-architecture)" = amd64 ]; then \
+		apt-get install -y --no-install-recommends ${PKGS_amd64}; \
+		fi \
 	&& rm -rf /var/lib/apt/lists/*
 
-## Install CMake
+RUN cmake_install="cmake-${CMAKE_VERSION}-Linux-$(uname -m).sh" \
+	&& url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${cmake_install}" \
+	&& wget -O cmake-install.sh "${url}" --progress=dot:giga ${WGET_ARGS} \
+	&& chmod +x cmake-install.sh \
+	&& ./cmake-install.sh --skip-license --prefix="${CMAKE_ROOT_DIR}" \
+	&& rm -f cmake-install.sh
 
-# hadolint ignore=DL3047
-RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
-	&& CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-Linux-${arch}.sh" \
-	&& CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_INSTALLER}" \
-	&& wget ${WGET_ARGS} "${CMAKE_URL}" \
-	&& chmod +x "${CMAKE_INSTALLER}" \
-	&& "./${CMAKE_INSTALLER}" --skip-license --prefix="/usr/local" \
-	&& rm -f "./${CMAKE_INSTALLER}" \
-	&& mkdir "/opt/toolchains"
-WORKDIR "/opt/toolchains"
+WORKDIR "${ZSDK_ROOT_DIR}"
 
-## Install Zephyr SDK
-
-# hadolint ignore=DL3047
-RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
-	&& ZSDK_TGZ="zephyr-sdk-${ZSDK_VERSION}_linux-${arch}.tar.gz" \
- 	&& ZSDK_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/${ZSDK_TGZ}" \
-	&& ZSDK_INSTALLER="./zephyr-sdk-${ZSDK_VERSION}/setup.sh" \
-	&& wget ${WGET_ARGS} "${ZSDK_URL}" \
-	&& tar xf "${ZSDK_TGZ}" \
-	&& "./${ZSDK_INSTALLER}" -c -t "arm-zephyr-eabi" \
-	&& rm -f "${ZSDK_TGZ}"
+RUN zsdk_tgz="zephyr-sdk-${ZSDK_VERSION}_linux-$(uname -m).tar.gz" \
+ 	&& url="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/${zsdk_tgz}" \
+	&& wget -O zsdk.tgz "${url}" --progress=dot:giga ${WGET_ARGS} \
+	&& tar xf zsdk.tgz \
+	&& rm -f zsdk.tgz \
+	&& "./zephyr-sdk-${ZSDK_VERSION}/setup.sh" -c -t arm-zephyr-eabi
 
 ENV ZEPHYR_TOOLCHAIN_VARIANT="zephyr"
-ENV ZEPHYR_SDK_INSTALL_DIR="/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}"
+ENV ZEPHYR_SDK_INSTALL_DIR="${ZSDK_OPT_DIR}/zephyr-sdk-${ZSDK_VERSION}"
 
-## Install Zephyr
-
+# DL3013: `pip install <package>==<version>`
+# DL3042: `pip install --no-cache-dir <package>`
 # hadolint ignore=DL3013,DL3042
 RUN python3 -m pip install -U pip \
-	&& pip3 install --upgrade west \
-	&& mkdir -p "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
-WORKDIR "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
+	&& pip3 install --upgrade west
 
+WORKDIR "${ZEPHYR_INSTALL_DIR}"
+
+# DL3042: `pip install --no-cache-dir <package>
 # hadolint ignore=DL3042
-RUN west init --mr "v${ZEPHYR_ZREPO_VERSION}" \
+RUN west init --mr "v${ZEPHYR_VERSION}" \
 	&& west update \
 	&& west zephyr-export \
-	&& pip3 install -r "zephyr/scripts/requirements.txt"
+	&& pip3 install -r zephyr/scripts/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,34 @@
-FROM --platform=linux/amd64 buildpack-deps:jammy-scm
+FROM buildpack-deps:jammy-scm
 
-ARG CMAKE_VERSION=3.20.5
-ARG ZSDK_VERSION=0.15.2
-ARG ZEPHYR_ZREPO_VERSION=3.3.0
-ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
-ARG HOSTTYPE=x86_64
+ARG CMAKE_VERSION="3.20.5"
+ARG ZSDK_VERSION="0.15.2"
+ARG ZEPHYR_ZREPO_VERSION="3.3.0"
+ARG WGET_ARGS="-q --progress=dot:giga --no-check-certificate"
+
+# Container host platform, set automatically by `docker build`
+ARG TARGETPLATFORM
 
 # Setup environment
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM=xterm
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV TERM="xterm"
 
-#Setup locale
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Setup locale
+# hadolint ignore=DL3008
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		locales \
-	  && rm -rf /var/lib/apt/lists/*
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV LANG=C.UTF-8
+	&& rm -rf /var/lib/apt/lists/* \
+	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' "/etc/locale.gen" \
+	&& dpkg-reconfigure --frontend=noninteractive locales \
+	&& update-locale
+
+ENV LANG="en_US.UTF-8"
+ENV LANGUAGE="en_US:en"
+ENV LC_ALL="en_US.UTF-8"
+ENV LANG="C.UTF-8"
 
 # Install needed packages
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ccache \
 		clang-format \
@@ -31,8 +37,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		file \
 		g++ \
 		gcc \
-		gcc-multilib \
-		g++-multilib \
 		git \
 		gperf \
 		lbzip2 \
@@ -54,25 +58,49 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		zip \
 	  && rm -rf /var/lib/apt/lists/*
 
-RUN wget ${WGET_ARGS} https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh \
-  && chmod +x cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh \
-  && ./cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh --skip-license --prefix=/usr/local \
-  && rm -f ./cmake-${CMAKE_VERSION}-Linux-${HOST_TYPE}.sh
+#
+# Install CMake
+#
 
-RUN mkdir /opt/toolchains && cd /opt/toolchains && \
-	wget ${WGET_ARGS} https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz && \
-	tar xf zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz && \
-	zephyr-sdk-${ZSDK_VERSION}/setup.sh -c -t arm-zephyr-eabi && \
-	rm zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz
+# hadolint ignore=DL3047,DL3066
+RUN case "${TARGETPLATFORM}" in linux/arm64) HOSTTYPE="aarch64";; linux/amd64|*) HOSTTYPE="x86-64";; esac \
+	&& CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh" \
+	&& wget ${WGET_ARGS} "${CMAKE_URL}" \
+	&& chmod +x "cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh" \
+	&& "./cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh" --skip-license --prefix="/usr/local" \
+	&& rm -f "./cmake-${CMAKE_VERSION}-Linux-${HOSTTYPE}.sh" \
+	&& mkdir "/opt/toolchains"
 
-ENV ZEPHYR_TOOLCHAIN_VARIANT zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR /opt/toolchains/zephyr-sdk-${ZSDK_VERSION}
+WORKDIR "/opt/toolchains"
 
-RUN python3 -m pip install -U pip
+#
+# Install Zephyr SDK
+#
 
-RUN pip3 install --upgrade west
+# hadolint ignore=DL3047,DL3066
+RUN case "${TARGETPLATFORM}" in linux/arm64) HOSTTYPE="aarch64";; linux/amd64|*) HOSTTYPE="x86-64";; esac \
+	&& ZEPHYR_SDK_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz" \
+	&& wget ${WGET_ARGS} "${ZEPHYR_SDK_URL}" \
+	&& tar xf "zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz" \
+	&& "zephyr-sdk-${ZSDK_VERSION}/setup.sh" -c -t "arm-zephyr-eabi" \
+	&& rm -f "zephyr-sdk-${ZSDK_VERSION}_linux-${HOSTTYPE}.tar.gz"
 
-RUN mkdir -p /usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}
-WORKDIR /usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}
-RUN west init --mr v${ZEPHYR_ZREPO_VERSION} && west update && west zephyr-export
-RUN pip3 install -r zephyr/scripts/requirements.txt
+ENV ZEPHYR_TOOLCHAIN_VARIANT="zephyr"
+ENV ZEPHYR_SDK_INSTALL_DIR="/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}"
+
+#
+# Install Zephyr
+#
+
+# hadolint ignore=DL3013,DL3042
+RUN python3 -m pip install -U pip \
+	&& pip3 install --upgrade west \
+	&& mkdir -p "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
+
+WORKDIR "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
+
+# hadolint ignore=DL3042
+RUN west init --mr "v${ZEPHYR_ZREPO_VERSION}" \
+	&& west update \
+	&& west zephyr-export \
+	&& pip3 install -r "zephyr/scripts/requirements.txt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# bcdevices/zsdk-zephyr-jammy
 FROM buildpack-deps:jammy-scm
 
 ARG CMAKE_VERSION="3.20.5"
@@ -5,11 +6,11 @@ ARG ZSDK_VERSION="0.15.2"
 ARG ZEPHYR_ZREPO_VERSION="3.3.0"
 ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
 
-# Setup environment
+# :: Setup environment
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV TERM="xterm"
 
-# Setup locale
+# :: Setup locale
 # hadolint ignore=DL3008
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
@@ -24,7 +25,7 @@ ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"
 ENV LANG="C.UTF-8"
 
-# Install needed packages
+# :: Install needed packages
 # hadolint ignore=DL3008
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
@@ -62,11 +63,7 @@ RUN apt-get update \
 		fi \
 	&& rm -rf /var/lib/apt/lists/*
 
-
-#
-# Install CMake
-#
-
+# :: Install CMake
 # hadolint ignore=DL3047
 RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
 	&& CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-Linux-${arch}.sh" \
@@ -76,13 +73,9 @@ RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="
 	&& "./${CMAKE_INSTALLER}" --skip-license --prefix="/usr/local" \
 	&& rm -f "./${CMAKE_INSTALLER}" \
 	&& mkdir "/opt/toolchains"
-
 WORKDIR "/opt/toolchains"
 
-#
-# Install Zephyr SDK
-#
-
+# :: Install Zephyr SDK
 # hadolint ignore=DL3047
 RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="x86_64";; esac \
 	&& ZEPHYR_SDK_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZSDK_VERSION}/zephyr-sdk-${ZSDK_VERSION}_linux-${arch}.tar.gz" \
@@ -94,17 +87,12 @@ RUN case "$(dpkg --print-architecture)" in arm64) arch="aarch64";; amd64) arch="
 ENV ZEPHYR_TOOLCHAIN_VARIANT="zephyr"
 ENV ZEPHYR_SDK_INSTALL_DIR="/opt/toolchains/zephyr-sdk-${ZSDK_VERSION}"
 
-#
-# Install Zephyr
-#
-
+# :: Install Zephyr
 # hadolint ignore=DL3013,DL3042
 RUN python3 -m pip install -U pip \
 	&& pip3 install --upgrade west \
 	&& mkdir -p "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
-
 WORKDIR "/usr/src/zephyr-${ZEPHYR_ZREPO_VERSION}"
-
 # hadolint ignore=DL3042
 RUN west init --mr "v${ZEPHYR_ZREPO_VERSION}" \
 	&& west update \

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2019 Blue Clover Devices
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # docker-zephyr-west
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/bcdevices/zephyr-west.svg)](https://hub.docker.com/r/bcdevices/zephyr-west/)
-[![Docker Stars](https://img.shields.io/docker/stars/bcdevices/zephyr-west.svg)](https://hub.docker.com/r/bcdevices/zephyr-west/)
-
-Docker image for Zephyr development with west.
+Docker build image for Zephyr development.
 
 Similar to Zephyr's [zephyrproject-rtos/docker-image](https://github.com/zephyrproject-rtos/docker-image),
 but including the Zephyr source in the container, speeding up CI builds.


### PR DESCRIPTION
- Add support for building for aarch64 (linux/arm64) Docker hosts
- LICENSE: switch from MIT to Apache-2.0, to match ly10-zephyr-fw and zephyr
- hadolint fixes