### PR TITLE
fix incorrect zephyr install dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG ZEPHYR_VERSION="3.3.0"
 
 ARG CMAKE_ROOT_DIR="/usr/local"
 ARG ZSDK_ROOT_DIR="/opt/toolchains"
-ARG ZEPHYR_ROOT_DIR="/usr/src"
+ARG ZEPHYR_SRC_DIR="/usr/src"
 ARG ZEPHYR_INSTALL_DIR="${ZEPHYR_SRC_DIR}/zephyr-${ZEPHYR_VERSION}"
 
 ARG PKGS
@@ -62,7 +62,7 @@ RUN apt-get update \
 	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
 	&& dpkg-reconfigure --frontend=noninteractive locales \
 	&& update-locale \
-	&& mkdir -p "${CMAKE_ROOT_DIR}" "${ZEPHYR_ROOT_DIR}" "${ZSDK_ROOT_DIR}"
+	&& mkdir -p "${CMAKE_ROOT_DIR}" "${ZEPHYR_SRC_DIR}" "${ZSDK_ROOT_DIR}"
 
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"


### PR DESCRIPTION
Installs zephyr into /usr/src/zephyr-${ZEPHYR_VERSION} again

Because of merging
https://github.com/bcdevices/docker-zephyr-west/pull/26 v3.3.0-3 was installing into /zephyr-${ZEPHYR_VERSION} instead.