### PR TITLE
Zephyr v3.3.0-rc2 -> v3.3.0-rc3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,9 @@
 # bcdevices/zsdk-zephyr-jammy
 FROM buildpack-deps:jammy-scm
 
-ARG CMAKE_VERSION="3.20.5"
 ARG ZSDK_VERSION="0.16.1"
-ARG ZEPHYR_VERSION="3.4.0-rc2"
+ARG ZEPHYR_VERSION="3.4.0-rc3"
 
-ARG CMAKE_ROOT_DIR="/usr/local"
 ARG ZSDK_ROOT_DIR="/opt/toolchains"
 ARG ZEPHYR_SRC_DIR="/usr/src"
 ARG ZEPHYR_INSTALL_DIR="${ZEPHYR_SRC_DIR}/zephyr-${ZEPHYR_VERSION}"
@@ -19,24 +17,30 @@ ARG ZEPHYR_INSTALL_DIR="${ZEPHYR_SRC_DIR}/zephyr-${ZEPHYR_VERSION}"
 ARG PKGS
 ENV PKGS="${PKGS} ccache"
 ENV PKGS="${PKGS} clang-format"
+ENV PKGS="${PKGS} cmake"
 ENV PKGS="${PKGS} device-tree-compiler"
 ENV PKGS="${PKGS} dfu-util"
 ENV PKGS="${PKGS} file"
 ENV PKGS="${PKGS} g++"
 ENV PKGS="${PKGS} gcc"
 ENV PKGS="${PKGS} git"
+ENV PKGS="${PKGS} gnupg"
 ENV PKGS="${PKGS} gperf"
 ENV PKGS="${PKGS} lbzip2"
 ENV PKGS="${PKGS} libc6-dev"
 ENV PKGS="${PKGS} libsdl2-dev"
+ENV PKGS="${PKGS} lsb-release"
 ENV PKGS="${PKGS} ninja-build"
 ENV PKGS="${PKGS} make"
+ENV PKGS="${PKGS} ovmf"
+ENV PKGS="${PKGS} parallel"
 ENV PKGS="${PKGS} pkg-config"
 ENV PKGS="${PKGS} python3-dev"
 ENV PKGS="${PKGS} python3-pip"
 ENV PKGS="${PKGS} python3-setuptools"
 ENV PKGS="${PKGS} python3-tk"
 ENV PKGS="${PKGS} python3-wheel"
+ENV PKGS="${PKGS} software-properties-common"
 ENV PKGS="${PKGS} srecord"
 ENV PKGS="${PKGS} qemu"
 ENV PKGS="${PKGS} qemu-system"
@@ -62,7 +66,7 @@ RUN apt-get update \
 	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
 	&& dpkg-reconfigure --frontend=noninteractive locales \
 	&& update-locale \
-	&& mkdir -p "${CMAKE_ROOT_DIR}" "${ZEPHYR_SRC_DIR}" "${ZSDK_ROOT_DIR}"
+	&& mkdir -p "${ZEPHYR_SRC_DIR}" "${ZSDK_ROOT_DIR}"
 
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US:en"
@@ -77,13 +81,6 @@ RUN apt-get update \
 		apt-get install -y --no-install-recommends ${PKGS_amd64}; \
 		fi \
 	&& rm -rf /var/lib/apt/lists/*
-
-RUN cmake_install="cmake-${CMAKE_VERSION}-Linux-$(uname -m).sh" \
-	&& url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${cmake_install}" \
-	&& wget -O cmake-install.sh "${url}" --progress=dot:giga ${WGET_ARGS} \
-	&& chmod +x cmake-install.sh \
-	&& ./cmake-install.sh --skip-license --prefix="${CMAKE_ROOT_DIR}" \
-	&& rm -f cmake-install.sh
 
 WORKDIR "${ZSDK_ROOT_DIR}"
 


### PR DESCRIPTION
- Bump Zephyr version
- Sync apt dependencies with docker-image
- Remove custom CMake install, rely on jammy cmake