### PR TITLE
Zephyr v3.6.0 -> v3.7.0 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@
 # bcdevices/zsdk-zephyr-jammy
 FROM buildpack-deps:jammy-scm
 
-ARG ZSDK_VERSION="0.16.5"
-ARG ZEPHYR_VERSION="3.6.0"
+ARG ZSDK_VERSION="0.17.0"
+ARG ZEPHYR_VERSION="3.7.0"
 
 ARG ZSDK_ROOT_DIR="/opt/toolchains"
 ARG ZEPHYR_SRC_DIR="/usr/src"


### PR DESCRIPTION
Update to Zephyr v3.7.0 (LTS, EOL: 2029-07-27)